### PR TITLE
Fix duplicate namespace alias

### DIFF
--- a/src_bindings/py_time_evolution.cpp
+++ b/src_bindings/py_time_evolution.cpp
@@ -7,7 +7,6 @@
 
 namespace py = pybind11;
 
-namespace py = pybind11;
 
 void bind_time_evolution(py::module_& m) {
 	py::class_<vam::TimeEvolution>(m, "TimeEvolution")


### PR DESCRIPTION
## Summary
- remove redundant namespace alias in `py_time_evolution.cpp`

## Testing
- `cmake -S . -B build/temp -DPYTHON_EXECUTABLE=$(which python)`
- `cmake --build build/temp --target vambindings -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6841fc90ef80832fb2b185b3ed80c70c