### PR TITLE
Refactor bindings to call class methods

### DIFF
--- a/src_bindings/py_biot_savart.cpp
+++ b/src_bindings/py_biot_savart.cpp
@@ -8,7 +8,7 @@
 namespace py = pybind11;
 
 void bind_biot_savart(py::module_& m) {
-	m.def("biot_savart_velocity", &vam::biot_savart_velocity,
+        m.def("biot_savart_velocity", &vam::BiotSavart::biot_savart_velocity,
 		  py::arg("r"),
 		  py::arg("filament_points"),
 		  py::arg("tangent_vectors"),

--- a/src_bindings/py_fluid_dynamics.cpp
+++ b/src_bindings/py_fluid_dynamics.cpp
@@ -9,7 +9,7 @@
 namespace py = pybind11;
 
 void bind_fluid_dynamics(py::module_& m) {
-	m.def("compute_pressure_field", &vam::compute_pressure_field,
+        m.def("compute_pressure_field", &vam::FluidDynamics::compute_pressure_field,
 		  py::arg("velocity_magnitude"),
 		  py::arg("rho_ae"),
 		  py::arg("P_infinity"),
@@ -18,13 +18,13 @@ void bind_fluid_dynamics(py::module_& m) {
             P = P_infinity - 0.5 * rho_ae * |v|^2
     )pbdoc");
 
-	m.def("compute_velocity_magnitude", &vam::compute_velocity_magnitude,
+        m.def("compute_velocity_magnitude", &vam::FluidDynamics::compute_velocity_magnitude,
 		  py::arg("velocity"),
 		  R"pbdoc(
         Compute magnitude |v| from vector velocity field.
     )pbdoc");
 
-	m.def("evolve_positions_euler", &vam::evolve_positions_euler,
+        m.def("evolve_positions_euler", &vam::FluidDynamics::evolve_positions_euler,
 		  py::arg("positions"),
 		  py::arg("velocity"),
 		  py::arg("dt"),

--- a/src_bindings/py_frenet_helicity.cpp
+++ b/src_bindings/py_frenet_helicity.cpp
@@ -11,7 +11,7 @@ namespace py = pybind11;
 void bind_frenet_helicity(py::module_& m) {
 	m.def("compute_frenet_frames", [](const std::vector<vam::Vec3>& X) {
 		std::vector<vam::Vec3> T, N, B;
-		vam::compute_frenet_frames(X, T, N, B);
+                vam::FrenetHelicity::compute_frenet_frames(X, T, N, B);
 		return std::make_tuple(T, N, B);
 	}, R"pbdoc(
         Compute Frenet frames (T, N, B) from 3D filament points.
@@ -21,7 +21,7 @@ void bind_frenet_helicity(py::module_& m) {
 	m.def("compute_curvature_torsion", [](const std::vector<vam::Vec3>& T,
 										  const std::vector<vam::Vec3>& N) {
 		std::vector<double> curvature, torsion;
-		vam::compute_curvature_torsion(T, N, curvature, torsion);
+                vam::FrenetHelicity::compute_curvature_torsion(T, N, curvature, torsion);
 		return std::make_tuple(curvature, torsion);
 	}, R"pbdoc(
 		Compute curvature and torsion from tangent and normal vectors.
@@ -30,16 +30,16 @@ void bind_frenet_helicity(py::module_& m) {
 
 	m.def("compute_helicity", [](const std::vector<vam::Vec3>& velocity,
 								 const std::vector<vam::Vec3>& vorticity) {
-		return vam::compute_helicity(velocity, vorticity);
+                return vam::FrenetHelicity::compute_helicity(velocity, vorticity);
 	}, R"pbdoc(
         Compute helicity H = ∫ v · ω dV.
     )pbdoc");
 
-	m.def("evolve_vortex_knot", &vam::evolve_vortex_knot, R"pbdoc(
+        m.def("evolve_vortex_knot", &vam::FrenetHelicity::evolve_vortex_knot, R"pbdoc(
         Evolve vortex knot filaments using Biot–Savart dynamics.
     )pbdoc");
 
-	m.def("rk4_integrate", &vam::rk4_integrate, R"pbdoc(
+        m.def("rk4_integrate", &vam::FrenetHelicity::rk4_integrate, R"pbdoc(
         Runge-Kutta 4th order time integrator for vortex elements.
     )pbdoc");
 }

--- a/src_bindings/py_gravity_timefield.cpp
+++ b/src_bindings/py_gravity_timefield.cpp
@@ -9,13 +9,13 @@
 namespace py = pybind11;
 
 void bind_gravity_timefield(py::module_& m) {
-	m.def("compute_gravitational_potential", &vam::compute_gravitational_potential,
+        m.def("compute_gravitational_potential", &vam::GravityTimefield::compute_gravitational_potential,
 		  py::arg("positions"), py::arg("vorticity"), py::arg("epsilon") = 0.1,
 		  R"pbdoc(
             Compute Æther gravitational potential field from vorticity.
         )pbdoc");
 
-	m.def("compute_time_dilation_map", &vam::compute_time_dilation_map,
+        m.def("compute_time_dilation_map", &vam::GravityTimefield::compute_time_dilation_map,
 		  py::arg("tangents"), py::arg("C_e"),
 		  R"pbdoc(
             Compute local time dilation factor map from tangential velocities.

--- a/src_bindings/py_kinetic_energy.cpp
+++ b/src_bindings/py_kinetic_energy.cpp
@@ -9,7 +9,7 @@
 namespace py = pybind11;
 
 void bind_kinetic_energy(py::module_& m) {
-	m.def("compute_kinetic_energy", &vam::compute_kinetic_energy,
+        m.def("compute_kinetic_energy", &vam::KineticEnergy::compute_kinetic_energy,
 		  py::arg("velocity"),
 		  py::arg("rho_ae"),
 		  R"pbdoc(

--- a/src_bindings/py_potential_timefield.cpp
+++ b/src_bindings/py_potential_timefield.cpp
@@ -9,7 +9,7 @@
 namespace py = pybind11;
 
 void bind_potential_timefield(py::module_& m) {
-	m.def("compute_gravitational_potential", &vam::compute_gravitational_potential,
+        m.def("compute_gravitational_potential", &vam::PotentialTimefield::compute_gravitational_potential,
 		  py::arg("positions"),
 		  py::arg("vorticity"),
 		  py::arg("epsilon") = 0.1,
@@ -17,7 +17,7 @@ void bind_potential_timefield(py::module_& m) {
             Compute Ætheric gravitational potential field from vorticity gradients.
         )pbdoc");
 
-	m.def("compute_time_dilation_map", &vam::compute_time_dilation_map,
+        m.def("compute_time_dilation_map", &vam::PotentialTimefield::compute_time_dilation_map,
 		  py::arg("tangents"),
 		  py::arg("C_e"),
 		  R"pbdoc(

--- a/src_bindings/py_pressure_field.cpp
+++ b/src_bindings/py_pressure_field.cpp
@@ -9,11 +9,11 @@
 namespace py = pybind11;
 
 void bind_pressure_field(py::module_& m) {
-	m.def("compute_bernoulli_pressure", &vam::compute_bernoulli_pressure, R"pbdoc(
+        m.def("compute_bernoulli_pressure", &vam::PressureField::compute_bernoulli_pressure, R"pbdoc(
         Compute Bernoulli pressure field from velocity magnitude.
     )pbdoc");
 
-	m.def("pressure_gradient", &vam::pressure_gradient, R"pbdoc(
+        m.def("pressure_gradient", &vam::PressureField::pressure_gradient, R"pbdoc(
         Compute spatial pressure gradient vector field.
     )pbdoc");
 }


### PR DESCRIPTION
## Summary
- update pybind11 bindings to refer to methods on C++ classes instead of global wrappers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vambindings')*

------
https://chatgpt.com/codex/tasks/task_e_6841fb197024832fa6f829ae43573e42