### PR TITLE
Remove duplicate namespace alias

### DIFF
--- a/src_bindings/py_time_evolution.cpp
+++ b/src_bindings/py_time_evolution.cpp
@@ -7,8 +7,6 @@
 
 namespace py = pybind11;
 
-namespace py = pybind11;
-
 void bind_time_evolution(py::module_& m) {
 	py::class_<vam::TimeEvolution>(m, "TimeEvolution")
 			.def(py::init<std::vector<vam::Vec3>, std::vector<vam::Vec3>, double>(),


### PR DESCRIPTION
## Summary
- remove redundant alias in py_time_evolution.cpp

## Testing
- `g++ -std=c++17 -fsyntax-only src_bindings/py_time_evolution.cpp -I extern/pybind11/include -I src -I include -I/usr/include/python3.12`

------
https://chatgpt.com/codex/tasks/task_e_6842237af224832fafc7a4ad5823d738