### PR TITLE
Fix run_test script

### DIFF
--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -24,4 +24,4 @@ T, N, B = vambindings.compute_frenet_frames(X)
 kappa, tau = vambindings.compute_curvature_torsion(T, N)
 print("Curvature:", kappa)
 print("Torsion:", tau)
-print("Helicity:", vambindings.compute_helicity(T, T))  # test w = v
+print("Helicity:", vambindings.compute_helicity(T, T))  # test w = v = T


### PR DESCRIPTION
## Summary
- repair truncated line in `tests/run_test.py`
- ensure file ends with a newline

## Testing
- `python tests/run_test.py` *(fails: ModuleNotFoundError: No module named 'vambindings')*

------
https://chatgpt.com/codex/tasks/task_e_68430536bd70832fa0232ee1746af9f1