### PR TITLE
Fix fluid dynamics functions linkage

### DIFF
--- a/src/fluid_dynamics.cpp
+++ b/src/fluid_dynamics.cpp
@@ -40,55 +40,53 @@ namespace vam {
 		}
         }
 
-	using Vec3 = std::array<double, 3>;
+        bool FluidDynamics::is_incompressible(const Vec3& dudx, const Vec3& dvdy, const Vec3& dwdz) {
+                return std::abs(dudx[0] + dvdy[1] + dwdz[2]) < 1e-8;
+        }
 
-	inline bool FluidDynamics::is_incompressible(const Vec3& dudx, const Vec3& dvdy, const Vec3& dwdz) {
-		return std::abs(dudx[0] + dvdy[1] + dwdz[2]) < 1e-8;
-	}
+        Vec3 FluidDynamics::compute_vorticity(const std::array<std::array<double, 3>, 3>& grad) {
+                return {
+                                grad[2][1] - grad[1][2], // wx
+                                grad[0][2] - grad[2][0], // wy
+                                grad[1][0] - grad[0][1]  // wz
+                };
+        }
 
-	inline Vec3 FluidDynamics::compute_vorticity(const std::array<std::array<double, 3>, 3>& grad) {
-		return {
-				grad[2][1] - grad[1][2], // wx
-				grad[0][2] - grad[2][0], // wy
-				grad[1][0] - grad[0][1]  // wz
-		};
-	}
+        double FluidDynamics::swirl_clock_rate(double dv_dx, double du_dy) {
+                return 0.5 * (dv_dx - du_dy);
+        }
 
-	inline double FluidDynamics::swirl_clock_rate(double dv_dx, double du_dy) {
-		return 0.5 * (dv_dx - du_dy);
-	}
+        double FluidDynamics::vorticity_from_curvature(double V, double R) {
+                return V / R;
+        }
 
-	inline double FluidDynamics::vorticity_from_curvature(double V, double R) {
-		return V / R;
-	}
+        double FluidDynamics::vortex_pressure_drop(double rho, double c) {
+                return 0.5 * rho * c * c;
+        }
 
-	inline double FluidDynamics::vortex_pressure_drop(double rho, double c) {
-		return 0.5 * rho * c * c;
-	}
+        double FluidDynamics::vortex_transverse_pressure_diff(double rho, double c) {
+                return 0.25 * rho * c * c;
+        }
 
-	inline double FluidDynamics::vortex_transverse_pressure_diff(double rho, double c) {
-		return 0.25 * rho * c * c;
-	}
+        double FluidDynamics::swirl_energy(double rho, double omega) {
+                return 0.5 * rho * omega * omega;
+        }
 
-	inline double FluidDynamics::swirl_energy(double rho, double omega) {
-		return 0.5 * rho * omega * omega;
-	}
+        bool FluidDynamics::kairos_energy_trigger(double rho, double omega, double Ce) {
+                return swirl_energy(rho, omega) > 0.5 * rho * Ce * Ce;
+        }
 
-	inline bool FluidDynamics::kairos_energy_trigger(double rho, double omega, double Ce) {
-		return swirl_energy(rho, omega) > 0.5 * rho * Ce * Ce;
-	}
+        double FluidDynamics::compute_helicity(const std::vector<Vec3>& velocity, const std::vector<Vec3>& vorticity, double dV) {
+                double H = 0.0;
+                for (size_t i = 0; i < velocity.size(); ++i) {
+                        H += velocity[i][0] * vorticity[i][0] +
+                                 velocity[i][1] * vorticity[i][1] +
+                                 velocity[i][2] * vorticity[i][2];
+                }
+                return H * dV;
+        }
 
-	inline double FluidDynamics::compute_helicity(const std::vector<Vec3>& velocity, const std::vector<Vec3>& vorticity, double dV) {
-		double H = 0.0;
-		for (size_t i = 0; i < velocity.size(); ++i) {
-			H += velocity[i][0] * vorticity[i][0] +
-				 velocity[i][1] * vorticity[i][1] +
-				 velocity[i][2] * vorticity[i][2];
-		}
-		return H * dV;
-	}
-
-	inline double FluidDynamics::potential_vorticity(double fa, double zeta_r, double h) {
-		return (fa + zeta_r) / h;
-	}
+        double FluidDynamics::potential_vorticity(double fa, double zeta_r, double h) {
+                return (fa + zeta_r) / h;
+        }
 }


### PR DESCRIPTION
## Summary
- export fluid dynamics helpers by removing `inline` from cpp definitions

## Testing
- `cmake -S . -B build && cmake --build build`
- `PYTHONPATH=build python - <<'EOF'
import vambindings
print('loaded', 'compute_pressure_field' in dir(vambindings))
print('available functions:', sorted([f for f in dir(vambindings) if not f.startswith('_')]) )
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6858021c2f78832f823aa5c07125ab75